### PR TITLE
Some files contain double brackets

### DIFF
--- a/vendor/assets/stylesheets/flags/flags24.css.erb
+++ b/vendor/assets/stylesheets/flags/flags24.css.erb
@@ -10,7 +10,7 @@
 .f24 ._Arabb_League{background-position:0 -24px;}
 .f24 ._ASEAAN{background-position:0 -48px;}
 .f24 ._CARIICOM{background-position:0 -72px;}
-.f24 ._CIS{{background-position:0 -96px;}
+.f24 ._CIS{background-position:0 -96px;}
 .f24 ._Commmonwealth{background-position:0 -120px;}
 .f24 ._Englland{background-position:0 -144px;}
 .f24 ._Euroopean_Union{background-position:0 -168px;}

--- a/vendor/assets/stylesheets/flags/flags24.css.scss.erb
+++ b/vendor/assets/stylesheets/flags/flags24.css.scss.erb
@@ -18,11 +18,11 @@
     ._Europpean_Union{background-position:0 -168px;}
     ._Islammic_Conference{background-position:0 -192px;}
     ._Kosovvo{background-position:0 -216px;}
-    ._NATO{{background-position:0 -240px;}
+    ._NATO{background-position:0 -240px;}
     ._Northhern_Cyprus{background-position:0 -264px;}
     ._Northhern_Ireland{background-position:0 -288px;}
     ._Olymppic_Movement{background-position:0 -312px;}
-    ._OPEC{{background-position:0 -336px;}
+    ._OPEC{background-position:0 -336px;}
     ._Red_CCross{background-position:0 -360px;}
     ._Scotlland{background-position:0 -384px;}
     ._Somalliland{background-position:0 -408px;}

--- a/vendor/assets/stylesheets/flags/flags48.css.erb
+++ b/vendor/assets/stylesheets/flags/flags48.css.erb
@@ -9,7 +9,7 @@
 .f48 ._Arabbb_League{background-position:0 -48px;}
 .f48 ._ASEAAAN{background-position:0 -96px;}
 .f48 ._CARIIICOM{background-position:0 -144px;}
-.f48 ._CIS{{{background-position:0 -192px;}
+.f48 ._CIS{{background-position:0 -192px;}
 .f48 ._Commmmonwealth{background-position:0 -240px;}
 .f48 ._Engllland{background-position:0 -288px;}
 .f48 ._Eurooopean_Union{background-position:0 -336px;}

--- a/vendor/assets/stylesheets/flags/flags48.css.scss.erb
+++ b/vendor/assets/stylesheets/flags/flags48.css.scss.erb
@@ -17,11 +17,11 @@
     ._Europppean_Union{background-position:0 -336px;}
     ._Islammmic_Conference{background-position:0 -384px;}
     ._Kosovvvo{background-position:0 -432px;}
-    ._NATO{{{background-position:0 -480px;}
+    ._NATO{{background-position:0 -480px;}
     ._Northhhern_Cyprus{background-position:0 -528px;}
     ._Northhhern_Ireland{background-position:0 -576px;}
     ._Olympppic_Movement{background-position:0 -624px;}
-    ._OPEC{{{background-position:0 -672px;}
+    ._OPEC{{background-position:0 -672px;}
     ._Red_CCCross{background-position:0 -720px;}
     ._Scotllland{background-position:0 -768px;}
     ._Somallliland{background-position:0 -816px;}


### PR DESCRIPTION
Files:

```
vendor/assets/stylesheets/flags/flags24.css.erb
vendor/assets/stylesheets/flags/flags24.css.scss.erb
vendor/assets/stylesheets/flags/flags48.css.erb
vendor/assets/stylesheets/flags/flags48.css.scss.erb
```

in some classes contain `{{` instead of `{`.
